### PR TITLE
no age shaming

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 	},
 	"key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhOMjYNi3qeEKZgL+1cJKlBYh1uf2tUQXBodu3WytvMuY8sHo8marMDd5LcgWJ0FaCjLq+YAKmZgrHuXEBR3OEdcXefiFz3wjX0lNlFY1P2ODkWg9KRZTc3qp3Km4IWWJOwv3IrXpG2zwPp9PdlmX5Nd8tM9KdTmqHkmhHHJHd38yk7lkN2w+EHoQmY4CZ7NpA4AwOxoEZltS/2/bpvQXMeKPbRrbinRWNswOox9Hn2pV5Os7MGXCgiWAEkUoy+gbad75niTxxiHvC6un4xP4E0JJTf8UPm6fUpn1f07ZHqaYPIk6b0RFGdyT6F3oQlZ1jxXeAQdGnZ10LGR5omwojQIDAQAB",
 	"manifest_version": 3,
-	"minimum_chrome_version": "118",
+	"minimum_chrome_version": "1",
 	"name": "Spurs New Tab Page",
 	"options_page": "options.html",
 	"permissions": ["alarms", "storage", "tabs"],


### PR DESCRIPTION
users of old browsers might not use browser extensions or know what they are doing. if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 116 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 116+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)
